### PR TITLE
extended jquery-html5-uploader to offer direct access to data URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,15 @@ $(function() {
 	});
 });
 </script>
+<style> .hover { background-color: teal; } </style>
 <div id="dropbox"></div>
 <input id="multiple" type="file" multiple>
 <input type="hidden" id="hidden_src_url">
+<pre id="dropzone">
+****************************
+* Drop a picture file here *
+****************************
+</pre>
 <img id="drop_receiver">
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,16 +23,26 @@ $(function() {
 		name: "foo",
 		postUrl: "bar.aspx"	
 	});
+	$("#dropzone").html5Uploader({
+		postUrl: null,
+		b64: function(srcUrl){
+		     document.getElementById('drop_receiver').src(srcUrl);
+		     $('#hidden_src_url').val(srcUrl);
+		}
+	});
 });
 </script>
 <div id="dropbox"></div>
 <input id="multiple" type="file" multiple>
+<input type="hidden" id="hidden_src_url">
+<img id="drop_receiver">
 ```
 
 #Settings
 
+- `b64`: function that takes a data url of the dropped image as argument.
 - `name`: upload field identifier.
-- `postUrl`: the url to post the file data.
+- `postUrl`: the url to post the file data. Set to null to not upload.
 - `onClientAbort`: Called when the read operation is aborted.
 - `onClientError`: Called when an error occurs.
 - `onClientLoad`: Called when the read operation is successfully completed.

--- a/jquery.html5uploader.js
+++ b/jquery.html5uploader.js
@@ -7,6 +7,7 @@
         var dashes = "--";
 
         var settings = {
+            "b64": null,
             "name": "uploadedFile",
             "postUrl": "Upload.aspx",
             "onClientAbort": null,
@@ -72,6 +73,9 @@
                 }
             };
             fileReader.onload = function (e) {
+                if (settings.b64) {
+                    settings.b64(fileReader.result);
+                };
                 if (settings.onClientLoad) {
                     settings.onClientLoad(e, file);
                 }
@@ -93,6 +97,8 @@
             };
             fileReader.readAsDataURL(file);
 
+            if(!settings.postUrl) return;
+            
             var xmlHttpRequest = new XMLHttpRequest();
             xmlHttpRequest.upload.onabort = function (e) {
                 if (settings.onServerAbort) {


### PR DESCRIPTION
a new setting is offered, "b64," which should be set to a function that will take the data string as an argument. Also the ajax request can be disabled by setting postUrl to a false value, as if you're using the b64 feature you probably don't need it.